### PR TITLE
remove white space in MONGO_INITDB_DATABASE

### DIFF
--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGODB_USERNAME}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGODB_PASSWORD}
-      - MONGO_INITDB_DATABASE =${MONGODB_INIT_DATABASE}
+      - MONGO_INITDB_DATABASE=${MONGODB_INIT_DATABASE}
   minio:
     image: minio/minio
     volumes:


### PR DESCRIPTION
This white space will cause "ERROR: environment variable may not contain white space" during executing `docker-compose pull` or `docker-compose up`